### PR TITLE
Add defaults for fields that tiled may omit

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -334,7 +334,7 @@ fn default_opacity() -> f64 {
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Layer {
     /// Unique ID of the layer. Each layer that added to a map gets a unique id. Even if a layer is deleted, no layer ever gets the same ID. Can not be changed in Tiled. (since Tiled 1.2)
-    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(deserialize_with = "deserialize_number_from_string", default)]
     pub id: u32,
     /// The name of the layer.
     #[serde(default)]

--- a/src/map.rs
+++ b/src/map.rs
@@ -124,13 +124,15 @@ pub struct Map {
     /// Stores the next available ID for new layers. This number is stored to prevent reuse of the same ID after layers have been removed. (since 1.2)
     #[serde(
         rename = "nextlayerid",
-        deserialize_with = "deserialize_number_from_string"
+        deserialize_with = "deserialize_number_from_string",
+        default
     )]
     pub next_layer_id: u32,
     /// Stores the next available ID for new objects. This number is stored to prevent reuse of the same ID after objects have been removed. (since 0.11)
     #[serde(
         rename = "nextobjectid",
-        deserialize_with = "deserialize_number_from_string"
+        deserialize_with = "deserialize_number_from_string",
+        default
     )]
     pub next_object_id: u32,
     #[serde(alias = "layer")]


### PR DESCRIPTION
I'm trying to bootstrap a project using tiled and rust-tmx and have found that `tiled` omits some fields in the simplest of maps/tilesets, in reality most real projects will likely be complicated enough that they wont hit this problem, but it would be nice to have defaults for fields that `tiled` might omit so that rust-tmx doesnt just fail entirely.